### PR TITLE
feat(authz): add allowed-users gate to poll and prepare :lock:

### DIFF
--- a/.hive.toml
+++ b/.hive.toml
@@ -1,3 +1,6 @@
+[security]
+allowed-users = ["ivy"]
+
 [jail]
 backend = "systemd-run"
 

--- a/cmd/hive/poll.go
+++ b/cmd/hive/poll.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/ivy/hive/internal/authz"
 	"github.com/ivy/hive/internal/github"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -53,11 +54,28 @@ func runPoll(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("github.project-node-id not configured (set in .hive.toml)")
 	}
 
+	allowedUsers := viper.GetStringSlice("security.allowed-users")
+	if len(allowedUsers) == 0 {
+		return fmt.Errorf("security.allowed-users not configured (set in .hive.toml) — refusing to run (fail-closed)")
+	}
+
 	slog.Info("found ready items", "count", len(items))
 
 	for _, item := range items {
 		if item.IsDraft {
 			slog.Warn("skipping draft", "title", item.Title)
+			continue
+		}
+
+		// Authz: fetch issue to check author against allowed-users
+		issue, err := gh.FetchIssue(cmd.Context(), item.Repo, item.Number)
+		if err != nil {
+			slog.Error("failed to fetch issue for authz", "error", err, "item", item.Title)
+			continue
+		}
+		if !authz.IsAllowed(issue.Author.Login, allowedUsers) {
+			slog.Warn("skipping item — author not in allowed-users",
+				"author", issue.Author.Login, "title", item.Title)
 			continue
 		}
 

--- a/cmd/hive/prepare.go
+++ b/cmd/hive/prepare.go
@@ -9,9 +9,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ivy/hive/internal/authz"
 	"github.com/ivy/hive/internal/github"
 	"github.com/ivy/hive/internal/workspace"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var prepareCmd = &cobra.Command{
@@ -75,6 +77,15 @@ func runPrepare(cmd *cobra.Command, args []string) error {
 	}
 
 	slog.Info("fetched issue", "title", issue.Title)
+
+	// Authz: check issue author against allowed-users (defense in depth)
+	allowedUsers := viper.GetStringSlice("security.allowed-users")
+	if len(allowedUsers) == 0 {
+		return fmt.Errorf("security.allowed-users not configured (set in .hive.toml) — refusing to run (fail-closed)")
+	}
+	if !authz.IsAllowed(issue.Author.Login, allowedUsers) {
+		return fmt.Errorf("author %q not in allowed-users — refusing to prepare workspace", issue.Author.Login)
+	}
 
 	// Create workspace (worktree + .hive/ metadata)
 	ws, err := workspace.Create(cmd.Context(), localPath, repo, issueNumber)

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -1,0 +1,20 @@
+// Package authz provides authorization checks for hive operations.
+package authz
+
+import "strings"
+
+// IsAllowed checks whether login is in the allowedUsers list.
+// Comparison is case-insensitive (GitHub usernames are case-insensitive).
+// Returns false when allowedUsers is empty or nil (fail-closed).
+func IsAllowed(login string, allowedUsers []string) bool {
+	if len(allowedUsers) == 0 {
+		return false
+	}
+	lower := strings.ToLower(login)
+	for _, u := range allowedUsers {
+		if strings.ToLower(u) == lower {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/authz/authz_suite_test.go
+++ b/internal/authz/authz_suite_test.go
@@ -1,0 +1,13 @@
+package authz_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuthz(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Authz Suite")
+}

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -1,0 +1,32 @@
+package authz_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ivy/hive/internal/authz"
+)
+
+var _ = Describe("IsAllowed", func() {
+	It("returns true when the user is in the allowed list", func() {
+		Expect(authz.IsAllowed("ivy", []string{"ivy", "oak"})).To(BeTrue())
+	})
+
+	It("returns false when the user is not in the allowed list", func() {
+		Expect(authz.IsAllowed("stranger", []string{"ivy", "oak"})).To(BeFalse())
+	})
+
+	It("returns false for an empty allowed list", func() {
+		Expect(authz.IsAllowed("ivy", []string{})).To(BeFalse())
+	})
+
+	It("returns false for a nil allowed list", func() {
+		Expect(authz.IsAllowed("ivy", nil)).To(BeFalse())
+	})
+
+	It("compares case-insensitively", func() {
+		Expect(authz.IsAllowed("IVY", []string{"ivy"})).To(BeTrue())
+		Expect(authz.IsAllowed("ivy", []string{"IVY"})).To(BeTrue())
+		Expect(authz.IsAllowed("Ivy", []string{"ivy"})).To(BeTrue())
+	})
+})

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -45,7 +45,7 @@ func (c *Client) FetchIssue(ctx context.Context, repo string, number int) (*Issu
 	cmd := c.runner("gh", "issue", "view",
 		fmt.Sprintf("%d", number),
 		"--repo", repo,
-		"--json", "number,title,body,state,url",
+		"--json", "number,title,body,state,url,author",
 	)
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Client", func() {
 
 	Describe("FetchIssue", func() {
 		It("parses a valid issue response", func() {
-			issueJSON := `{"number":143,"title":"feat(hooks): allow bypassing","body":"Issue body","state":"OPEN","url":"https://github.com/ivy/dotfiles/issues/143"}`
+			issueJSON := `{"number":143,"title":"feat(hooks): allow bypassing","body":"Issue body","state":"OPEN","url":"https://github.com/ivy/dotfiles/issues/143","author":{"login":"ivy"}}`
 			client := github.NewClientWithRunner(fakeRunner(issueJSON, 0))
 
 			issue, err := client.FetchIssue(ctx, "ivy/dotfiles", 143)
@@ -87,10 +87,11 @@ var _ = Describe("Client", func() {
 			Expect(issue.Body).To(Equal("Issue body"))
 			Expect(issue.State).To(Equal("OPEN"))
 			Expect(issue.URL).To(Equal("https://github.com/ivy/dotfiles/issues/143"))
+			Expect(issue.Author.Login).To(Equal("ivy"))
 		})
 
 		It("passes the correct arguments to gh", func() {
-			issueJSON := `{"number":143,"title":"t","body":"b","state":"OPEN","url":"u"}`
+			issueJSON := `{"number":143,"title":"t","body":"b","state":"OPEN","url":"u","author":{"login":"ivy"}}`
 			rec := &recordingRunner{inner: fakeRunner(issueJSON, 0)}
 			client := github.NewClientWithRunner(rec.run)
 
@@ -100,7 +101,7 @@ var _ = Describe("Client", func() {
 			Expect(rec.calls[0]).To(Equal([]string{
 				"gh", "issue", "view", "143",
 				"--repo", "ivy/dotfiles",
-				"--json", "number,title,body,state,url",
+				"--json", "number,title,body,state,url,author",
 			}))
 		})
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -3,6 +3,11 @@
 // and branch pushing.
 package github
 
+// Author represents a GitHub user (issue author, PR author, etc.).
+type Author struct {
+	Login string `json:"login"`
+}
+
 // Issue represents a GitHub issue fetched via gh.
 type Issue struct {
 	Number int    `json:"number"`
@@ -10,6 +15,7 @@ type Issue struct {
 	Body   string `json:"body"`
 	State  string `json:"state"`
 	URL    string `json:"url"`
+	Author Author `json:"author"`
 }
 
 // PR represents a GitHub pull request.


### PR DESCRIPTION
## Why

Hive had zero authorization checks. Anyone whose issue ended up in the "Ready" column would trigger agent execution on a private server. This PR adds an allowed-users list as the first line of defense against unauthorized execution.

## What

Adds `security.allowed-users` config to `.hive.toml`. Issue authors are checked against this list at two enforcement points:
- **poll** (primary gate) — before moving items to "In Progress" and dispatching runs
- **prepare** (defense in depth) — before creating workspaces

Fails closed when the list is empty or unconfigured. Comparison is case-insensitive (GitHub usernames are case-insensitive).

## Notes for reviewers

- The `poll` gate fetches the issue once for authz (one extra `gh` call per ready item)
- `prepare` already fetches the issue, so no extra API call there
- Bot accounts (like `dependabot[bot]`) can be added to the list if needed

Closes #26

---

🤖 [Conversation log](https://gist.github.com/ivy/6f9a015a7dc44ec2d85aa27e20681c63)