### PR TITLE
chore(deps): add Renovate config for automated dependency updates :robot:

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "automerge": false,
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "automerge": true,
+      "matchManagers": [
+        "mise"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "automerge": false,
+      "matchManagers": [
+        "mise"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ]
+    },
+    {
+      "automerge": true,
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    }
+  ],
+  "rangeStrategy": "pin",
+  "schedule": [
+    "before 9am on Monday"
+  ],
+  "vulnerabilityAlerts": {
+    "automerge": true,
+    "enabled": true,
+    "schedule": [
+      "at any time"
+    ]
+  }
+}


### PR DESCRIPTION
## Why

Manual dependency updates don't happen consistently, leaving security patches unapplied and tool versions drifting. This creates technical debt that compounds over time.

## What

Adds `renovate.json` to automate dependency management across three surfaces:

- **Go modules** (`go.mod`) — automerge patch/minor, review major updates
- **mise tools** (`mise.toml`) — automerge patches only, review minor/major (tool upgrades can change linter rules or formatter output)
- **GitHub Actions** (future) — automerge all updates, SHA digest pinning for supply chain security

Configuration uses exact version pinning everywhere (`rangeStrategy: "pin"`), runs weekly on Monday mornings to batch noise, and bypasses the schedule for immediate security vulnerability patches.

## Notes for reviewers

- Automerge is enabled now but will be most useful once CI exists to gate on passing tests
- Renovate GitHub App still needs to be installed at https://github.com/apps/renovate
- No other dependency surfaces exist today (no npm, Docker, Python, Rust)

---
Generated with [Hive](https://github.com/ivy/hive) | Closes #24